### PR TITLE
Prototype: Implement optional runtime constraints

### DIFF
--- a/cmd/CourseScheduler/main.go
+++ b/cmd/CourseScheduler/main.go
@@ -28,10 +28,19 @@ func main() {
 	ignoredCourses := []string{"ENGR450", "IE101", "CENG404"}
 	/* Parse and instantiate course objects from CSV (ignored courses are not loaded) */
 	/* Also assign additional attributes and find conflicting courses*/
-	courses, reserved := csvio.LoadCourses(CoursesFile, PriorityFile, ';', ignoredCourses)
+	courses, reserved, busy := csvio.LoadCourses(CoursesFile, PriorityFile, BlacklistFile, ';', ignoredCourses)
 
-	for _, r := range reserved {
-		fmt.Println(r.CourseRef.Course_Code)
+	fmt.Println("Professors with their busy schedules are as below:")
+	for _, b := range busy {
+		fmt.Print(b.Lecturer + " ")
+		fmt.Println(b.Day)
+	}
+
+	fmt.Println("")
+
+	fmt.Println("Courses reserved to certain days and hours are as below:")
+	for _, c := range reserved {
+		fmt.Println(c.CourseCodeSTR + " " + c.DaySTR + " " + c.StartingTimeSTR)
 	}
 
 	start := time.Now().UnixNano()

--- a/cmd/CourseScheduler/main.go
+++ b/cmd/CourseScheduler/main.go
@@ -10,10 +10,10 @@ import (
 	"github.com/rhyrak/go-schedule/pkg/model"
 )
 
-// Program parameters
+/* Program parameters */
 const (
 	ClassroomsFile   = "./res/private/classrooms.csv"
-	CoursesFile      = "./res/private/courses3.csv"
+	CoursesFile      = "./res/private/courses2.csv"
 	ExportFile       = "schedule.csv"
 	NumberOfDays     = 5
 	TimeSlotDuration = 60
@@ -21,32 +21,43 @@ const (
 )
 
 func main() {
+	/* Parse and instantiate classroom objects from CSV */
 	classrooms := csvio.LoadClassrooms(ClassroomsFile, ';')
 	ignoredCourses := []string{"ENGR450", "IE101", "CENG404"}
+	/* Parse and instantiate course objects from CSV (ignored courses are not loaded) */
+	/* Also assign additional attributes and find conflicting courses*/
 	courses := csvio.LoadCourses(CoursesFile, ';', ignoredCourses)
 
 	start := time.Now().UnixNano()
 	var schedule *model.Schedule
 	var iter int32
+	/* Try to create a valid schedule upto 2000 times */
 	for iter = 1; iter <= 2000; iter++ {
 		for _, c := range classrooms {
+			/* Initialize an empty classroom-oriented schedule to keep track of classroom utilization throughout the week */
 			c.CreateSchedule(NumberOfDays, TimeSlotCount)
 		}
 		for _, c := range courses {
 			c.Placed = false
 		}
+		/* Shuffle around the courses vector randomly to allow for different output opportunities */
 		rand.Shuffle(len(courses), func(i, j int) {
 			courses[i], courses[j] = courses[j], courses[i]
 		})
+		/* Initialize an empty schedule to hold course data */
 		schedule = model.NewSchedule(NumberOfDays, TimeSlotDuration, TimeSlotCount)
+		/* Fill the empty schedule with course data and assign classrooms to courses */
 		scheduler.FillCourses(courses, schedule, classrooms)
+		/* If schedule is valid, break, if not, shove everything out the window and try again (5dk) */
 		if valid, _ := scheduler.Validate(courses, schedule, classrooms); valid {
 			break
 		}
 	}
 	end := time.Now().UnixNano()
 
+	/* Write newly created schedule to disk */
 	csvio.ExportSchedule(schedule, ExportFile)
+	/* Validate and print error messages */
 	valid, msg := scheduler.Validate(courses, schedule, classrooms)
 	if !valid {
 		fmt.Println("Invalid schedule:")
@@ -54,6 +65,7 @@ func main() {
 		fmt.Println("Passed all tests")
 	}
 	fmt.Println(msg)
+	/* Show how evil the schedule is */
 	schedule.CalculateCost()
 	fmt.Printf("Cost: %d\n", schedule.Cost)
 	fmt.Printf("Iteration: %d\n", iter)

--- a/cmd/CourseScheduler/main.go
+++ b/cmd/CourseScheduler/main.go
@@ -14,6 +14,8 @@ import (
 const (
 	ClassroomsFile   = "./res/private/classrooms.csv"
 	CoursesFile      = "./res/private/courses2.csv"
+	PriorityFile     = "./res/private/reserved.csv"
+	BlacklistFile    = "./res/private/busy.csv"
 	ExportFile       = "schedule.csv"
 	NumberOfDays     = 5
 	TimeSlotDuration = 60
@@ -26,7 +28,11 @@ func main() {
 	ignoredCourses := []string{"ENGR450", "IE101", "CENG404"}
 	/* Parse and instantiate course objects from CSV (ignored courses are not loaded) */
 	/* Also assign additional attributes and find conflicting courses*/
-	courses := csvio.LoadCourses(CoursesFile, ';', ignoredCourses)
+	courses, reserved := csvio.LoadCourses(CoursesFile, PriorityFile, ';', ignoredCourses)
+
+	for _, r := range reserved {
+		fmt.Println(r.CourseRef.Course_Code)
+	}
 
 	start := time.Now().UnixNano()
 	var schedule *model.Schedule
@@ -47,6 +53,7 @@ func main() {
 		/* Initialize an empty schedule to hold course data */
 		schedule = model.NewSchedule(NumberOfDays, TimeSlotDuration, TimeSlotCount)
 		/* Fill the empty schedule with course data and assign classrooms to courses */
+		scheduler.PlaceReservedCourses(reserved, schedule, classrooms)
 		scheduler.FillCourses(courses, schedule, classrooms)
 		/* If schedule is valid, break, if not, shove everything out the window and try again (5dk) */
 		if valid, _ := scheduler.Validate(courses, schedule, classrooms); valid {

--- a/internal/csvio/loader.go
+++ b/internal/csvio/loader.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rhyrak/go-schedule/pkg/model"
 )
 
-// LoadCourses reads and parses given csv file for course data.
+/* LoadCourses reads and parses given csv file for course data. */
 func LoadCourses(path string, delim rune, ignored []string) []*model.Course {
 	gocsv.SetCSVReader(func(in io.Reader) gocsv.CSVReader {
 		r := csv.NewReader(in)
@@ -51,7 +51,7 @@ func LoadCourses(path string, delim rune, ignored []string) []*model.Course {
 	return courses
 }
 
-// LoadClassrooms reads and parses given csv file for classroom data.
+/* LoadClassrooms reads and parses given csv file for classroom data. */
 func LoadClassrooms(path string, delim rune) []*model.Classroom {
 	gocsv.SetCSVReader(func(in io.Reader) gocsv.CSVReader {
 		r := csv.NewReader(in)
@@ -74,6 +74,7 @@ func LoadClassrooms(path string, delim rune) []*model.Classroom {
 	return classrooms
 }
 
+/* Determine duration and course environment */
 func assignCourseProperties(courses []*model.Course) {
 	var id model.CourseID = 1
 	for _, course := range courses {
@@ -98,6 +99,7 @@ func assignCourseProperties(courses []*model.Course) {
 	}
 }
 
+/* Collect and store conflicting courses of given course */
 func findConflictingCourses(courses []*model.Course) {
 	for _, c1 := range courses {
 		for _, c2 := range courses {
@@ -111,9 +113,14 @@ func findConflictingCourses(courses []*model.Course) {
 			if c1.Class == c2.Class && c1.DepartmentCode == c2.DepartmentCode {
 				conflict = true
 			}
-			// if c1.DepartmentCode == c2.DepartmentCode && (c1.Class-c2.Class == 1 || c1.Class-c2.Class == -1) {
-			// 	conflict = true
-			// }
+			/* This part is probably to prevent conflicts between neighbouring classes (e.g., 1&2, 2&3, 3&4 and vice versa 2&1, 3&2, 4&3) */
+			/* Currently prevents creation of a valid schedule due to shear amount of courses for each class */
+			/* Needs additional Mandatory/Elective course data to make smarter decisions on whether to allow/disallow conflict of courses */
+			/*
+				if c1.DepartmentCode == c2.DepartmentCode && (c1.Class-c2.Class == 1 || c1.Class-c2.Class == -1) {
+					conflict = true
+				}
+			*/
 			if conflict {
 				c1HasC2 := false
 				c2HasC1 := false

--- a/internal/csvio/writer.go
+++ b/internal/csvio/writer.go
@@ -10,8 +10,8 @@ import (
 	"github.com/rhyrak/go-schedule/pkg/model"
 )
 
-// ExportSchedule formats the schedule data into ScheduleCSVRow structs and
-// writes it to the CSV file specified by the given path.
+/* ExportSchedule formats the schedule data into ScheduleCSVRow structs and */
+/* writes it to the CSV file specified by the given path. */
 func ExportSchedule(schedule *model.Schedule, path string) {
 	nice := formatAndFilterSchedule(schedule)
 	out, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, os.ModePerm)
@@ -25,7 +25,7 @@ func ExportSchedule(schedule *model.Schedule, path string) {
 	}
 }
 
-// PrintSchedule prints weekly schedule grouped by department name.
+/* PrintSchedule prints weekly schedule grouped by department name. */
 func PrintSchedule(schedule *model.Schedule) {
 	days := []string{"Monday", "Tuesday", "Wednesday", "Thursday", "Friday"}
 	deps := make(map[string]bool, 10)

--- a/internal/csvio/writer.go
+++ b/internal/csvio/writer.go
@@ -14,12 +14,21 @@ import (
 /* writes it to the CSV file specified by the given path. */
 func ExportSchedule(schedule *model.Schedule, path string) {
 	nice := formatAndFilterSchedule(schedule)
+	/* Remove file if exists */
+	_, err := os.Stat(path)
+	if err == nil {
+		os.Remove(path)
+	}
+
+	/* Open new file */
 	out, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, os.ModePerm)
 	if err != nil {
 		panic(err)
 	}
-	defer out.Close()
+
+	/* Write to file */
 	err = gocsv.MarshalFile(&nice, out)
+	defer out.Close()
 	if err != nil {
 		panic(err)
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -7,8 +7,8 @@ import (
 	"github.com/rhyrak/go-schedule/pkg/model"
 )
 
-// FillCourses tries to assign a time and room for all unassigned courses.
-// Returns the number of newly assigned courses.
+/* FillCourses tries to assign a time and room for all unassigned courses. */
+/* Returns the number of newly assigned courses. */
 func FillCourses(courses []*model.Course, schedule *model.Schedule, rooms []*model.Classroom) int {
 	sort.Slice(rooms, func(i, j int) bool {
 		return rooms[i].Capacity < rooms[j].Capacity
@@ -76,7 +76,7 @@ func shouldIgnoreDailyLimit(days []*model.Day, department string, grade int) boo
 
 func checkSlots(day *model.Day, start int, max int, needed int, course *model.Course) bool {
 	availableSlots := 0
-	// Lecturers need at least 1 hour break between classes
+	/* Lecturers need at least 1 hour break between classes */
 	if start > 0 {
 		for _, prevCourse := range day.Slots[start-1].CourseRefs {
 			if prevCourse.Lecturer == course.Lecturer {

--- a/internal/scheduler/validator.go
+++ b/internal/scheduler/validator.go
@@ -6,8 +6,8 @@ import (
 	"github.com/rhyrak/go-schedule/pkg/model"
 )
 
-// Validate checks schedule for conflicts and unassigned courses.
-// Returns false and a message for invalid schedules.
+/* Validate checks schedule for conflicts and unassigned courses. */
+/* Returns false and a message for invalid schedules. */
 func Validate(courses []*model.Course, schedule *model.Schedule, rooms []*model.Classroom) (bool, string) {
 	var message string
 	var valid bool = true

--- a/pkg/model/busy.go
+++ b/pkg/model/busy.go
@@ -1,7 +1,12 @@
 package model
 
-type Busy struct {
+type BusyCSV struct {
 	Lecturer string `csv:"Lecturer"`
 	DaySTR   string `csv:"Busy_Day"`
 	Day      int64  `csv:"-"`
+}
+
+type Busy struct {
+	Lecturer string `csv:"-"`
+	Day      []int  `csv:"-"`
 }

--- a/pkg/model/busy.go
+++ b/pkg/model/busy.go
@@ -1,0 +1,7 @@
+package model
+
+type Busy struct {
+	Lecturer string `csv:"Lecturer"`
+	DaySTR   string `csv:"Busy_Day"`
+	Day      int64  `csv:"-"`
+}

--- a/pkg/model/classroom.go
+++ b/pkg/model/classroom.go
@@ -10,7 +10,7 @@ type Classroom struct {
 	slots         int          `csv:"-"`
 }
 
-// IsAvailable checks if classroom is occupied.
+/* IsAvailable checks if classroom is occupied. */
 func (c *Classroom) IsAvailable(day int, slot int) bool {
 	if day < 0 || day >= c.days || slot < 0 || slot >= c.slots {
 		return false
@@ -18,7 +18,7 @@ func (c *Classroom) IsAvailable(day int, slot int) bool {
 	return c.schedule[day][slot] == 0
 }
 
-// CreateSchedule creates an empty schedule.
+/* CreateSchedule creates an empty schedule. */
 func (c *Classroom) CreateSchedule(day int, slot int) {
 	c.days = day
 	c.slots = slot
@@ -33,8 +33,8 @@ func (c *Classroom) CreateSchedule(day int, slot int) {
 	}
 }
 
-// PlaceCourse checks schedule and places course into given time.
-// Returns false if the classroom was occupied.
+/* PlaceCourse checks schedule and places course into given time. */
+/* Returns false if the classroom was occupied. */
 func (c *Classroom) PlaceCourse(day int, slot int, course CourseID) bool {
 	if c.IsAvailable(day, slot) {
 		c.schedule[day][slot] = course

--- a/pkg/model/course.go
+++ b/pkg/model/course.go
@@ -3,22 +3,25 @@ package model
 type CourseID uint64
 
 type Course struct {
-	Section            int        `csv:"Section"`
-	Course_Code        string     `csv:"Course_Code"`
-	Course_Name        string     `csv:"Course_Name"`
-	Number_of_Students int        `csv:"Number_of_Students"`
-	Course_Environment string     `csv:"Course_Environment"`
-	TplusU             string     `csv:"T+U"`
-	AKTS               int        `csv:"AKTS"`
-	Class              int        `csv:"Class"`
-	Depertmant         string     `csv:"Depertmant"`
-	Lecturer           string     `csv:"Lecturer"`
-	DepartmentCode     string     `csv:"Department"`
-	Duration           int        `csv:"-"`
-	CourseID           CourseID   `csv:"-"`
-	ConflictingCourses []CourseID `csv:"-"`
-	Placed             bool       `csv:"-"`
-	Classroom          *Classroom `csv:"-"`
-	NeedsRoom          bool       `csv:"-"`
-	NeededSlots        int        `csv:"-"`
+	Section                  int        `csv:"Section"`
+	Course_Code              string     `csv:"Course_Code"`
+	Course_Name              string     `csv:"Course_Name"`
+	Number_of_Students       int        `csv:"Number_of_Students"`
+	Course_Environment       string     `csv:"Course_Environment"`
+	TplusU                   string     `csv:"T+U"`
+	AKTS                     int        `csv:"AKTS"`
+	Class                    int        `csv:"Class"`
+	Depertmant               string     `csv:"Depertmant"`
+	Lecturer                 string     `csv:"Lecturer"`
+	DepartmentCode           string     `csv:"Department"`
+	Duration                 int        `csv:"-"`
+	CourseID                 CourseID   `csv:"-"`
+	ConflictingCourses       []CourseID `csv:"-"`
+	Placed                   bool       `csv:"-"`
+	Classroom                *Classroom `csv:"-"`
+	NeedsRoom                bool       `csv:"-"`
+	NeededSlots              int        `csv:"-"`
+	Reserved                 bool       `csv:"-"`
+	ReservedStartingTimeSlot int        `csv:"-"`
+	ReservedDay              int        `csv:"-"`
 }

--- a/pkg/model/course.go
+++ b/pkg/model/course.go
@@ -24,4 +24,5 @@ type Course struct {
 	Reserved                 bool       `csv:"-"`
 	ReservedStartingTimeSlot int        `csv:"-"`
 	ReservedDay              int        `csv:"-"`
+	BusyDays                 []int      `csv:"-"`
 }

--- a/pkg/model/reserved.go
+++ b/pkg/model/reserved.go
@@ -1,0 +1,8 @@
+package model
+
+type Reserved struct {
+	CourseCodeSTR   string `csv:"Course_Code"`
+	StartingTimeSTR string `csv:"Starting_Time"`
+	DaySTR          string `csv:"Day"`
+	CourseRef       *Course
+}

--- a/pkg/model/schedule.go
+++ b/pkg/model/schedule.go
@@ -29,7 +29,7 @@ type ScheduleCSVRow struct {
 	Lecturer   string `csv:"lecturer"`
 }
 
-// NewSchedule creates an empty schedule.
+/* NewSchedule creates an empty schedule. */
 func NewSchedule(days int, timeSlotDuration int, timeSlotCount int) *Schedule {
 	schedule := Schedule{Days: make([]*Day, days), TimeSlotDuration: timeSlotDuration, TimeSlotCount: timeSlotCount}
 	for i := range schedule.Days {
@@ -43,7 +43,7 @@ func NewSchedule(days int, timeSlotDuration int, timeSlotCount int) *Schedule {
 	return &schedule
 }
 
-// CalculateCost calculates cost based on conflicting course proximity.
+/* CalculateCost calculates cost based on conflicting course proximity. */
 func (s *Schedule) CalculateCost() {
 	s.Cost = 0
 	for _, day := range s.Days {


### PR DESCRIPTION
-Add the ability to block one or more days for certain lecturers in the form of an input CSV file.
-Add the ability to reserve certain days and hours for certain courses in the form of an input CSV file.
-Delete output "schedule.csv" before writing to it (fixes output corruption).
-Throw in some comments here and there for clarity's sake.

![image](https://github.com/rhyrak/go-schedule/assets/82059810/1512be36-2805-4bba-b8f2-55c2662fa486)

