### PR TITLE
Forbid Conflict of Neighbouring Compulsory Courses

### DIFF
--- a/cmd/CourseScheduler/main.go
+++ b/cmd/CourseScheduler/main.go
@@ -16,6 +16,7 @@ const (
 	CoursesFile      = "./res/private/courses2.csv"
 	PriorityFile     = "./res/private/reserved.csv"
 	BlacklistFile    = "./res/private/busy.csv"
+	MandatoryFile    = "./res/private/mandatory.csv"
 	ExportFile       = "schedule.csv"
 	NumberOfDays     = 5
 	TimeSlotDuration = 60
@@ -28,7 +29,7 @@ func main() {
 	ignoredCourses := []string{"ENGR450", "IE101", "CENG404"}
 	// Parse and instantiate course objects from CSV (ignored courses are not loaded)
 	// Also assign additional attributes and find conflicting courses
-	courses, reserved, busy := csvio.LoadCourses(CoursesFile, PriorityFile, BlacklistFile, ';', ignoredCourses)
+	courses, reserved, busy := csvio.LoadCourses(CoursesFile, PriorityFile, BlacklistFile, MandatoryFile, ';', ignoredCourses)
 
 	fmt.Println("Professors with their busy schedules are as below:")
 	for _, b := range busy {

--- a/cmd/CourseScheduler/main.go
+++ b/cmd/CourseScheduler/main.go
@@ -12,15 +12,16 @@ import (
 
 // Program parameters
 const (
-	ClassroomsFile   = "./res/private/classrooms.csv"
-	CoursesFile      = "./res/private/courses2.csv"
-	PriorityFile     = "./res/private/reserved.csv"
-	BlacklistFile    = "./res/private/busy.csv"
-	MandatoryFile    = "./res/private/mandatory.csv"
-	ExportFile       = "schedule.csv"
-	NumberOfDays     = 5
-	TimeSlotDuration = 60
-	TimeSlotCount    = 9
+	ClassroomsFile      = "./res/private/classrooms.csv"
+	CoursesFile         = "./res/private/courses2.csv"
+	PriorityFile        = "./res/private/reserved.csv"
+	BlacklistFile       = "./res/private/busy.csv"
+	MandatoryFile       = "./res/private/mandatory.csv"
+	ExportFile          = "schedule"
+	ExportFileExtension = ".csv"
+	NumberOfDays        = 5
+	TimeSlotDuration    = 60
+	TimeSlotCount       = 9
 )
 
 func main() {
@@ -48,7 +49,7 @@ func main() {
 	var schedule *model.Schedule
 	var iter int32
 	// Try to create a valid schedule upto 2000 times
-	for iter = 1; iter <= 2000; iter++ {
+	for iter = 1; iter <= 10000; iter++ {
 		for _, c := range classrooms {
 			// Initialize an empty classroom-oriented schedule to keep track of classroom utilization throughout the week
 			c.CreateSchedule(NumberOfDays, TimeSlotCount)
@@ -73,7 +74,7 @@ func main() {
 	end := time.Now().UnixNano()
 
 	// Write newly created schedule to disk
-	csvio.ExportSchedule(schedule, ExportFile)
+	outPath := csvio.ExportSchedule(schedule, ExportFile, ExportFileExtension)
 	// Validate and print error messages
 	valid, msg := scheduler.Validate(courses, schedule, classrooms)
 	if !valid {
@@ -87,4 +88,5 @@ func main() {
 	fmt.Printf("Cost: %d\n", schedule.Cost)
 	fmt.Printf("Iteration: %d\n", iter)
 	fmt.Printf("Timer: %f ms\n", float64(end-start)/1000000.0)
+	fmt.Println("Exported output to: " + outPath)
 }

--- a/internal/csvio/loader.go
+++ b/internal/csvio/loader.go
@@ -195,14 +195,11 @@ func findConflictingCourses(courses []*model.Course) {
 			if c1.Class == c2.Class && c1.DepartmentCode == c2.DepartmentCode {
 				conflict = true
 			}
-			// This part is probably to prevent conflicts between neighbouring classes (e.g., 1&2, 2&3, 3&4 and vice versa 2&1, 3&2, 4&3)
-			// Currently prevents creation of a valid schedule due to shear amount of courses for each class
-			// Needs additional Mandatory/Elective course data to make smarter decisions on whether to allow/disallow conflict of courses
-			/*
-				if c1.DepartmentCode == c2.DepartmentCode && (c1.Class-c2.Class == 1 || c1.Class-c2.Class == -1) {
-					conflict = true
-				}
-			*/
+
+			// This part makes sure that neighbouring classes (e.g., 1&2, 2&3, 3&4 and vice versa 2&1, 3&2, 4&3) don't conflict with each other (except Elective courses)
+			if (c1.DepartmentCode == c2.DepartmentCode) && (c1.Class-c2.Class == 1 || c1.Class-c2.Class == -1) && (c1.Compulsory && c2.Compulsory) {
+				conflict = true
+			}
 
 			if conflict {
 				c1HasC2 := false

--- a/internal/csvio/writer.go
+++ b/internal/csvio/writer.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gocarina/gocsv"
 	"github.com/rhyrak/go-schedule/pkg/model"
@@ -12,8 +14,11 @@ import (
 
 // ExportSchedule formats the schedule data into ScheduleCSVRow structs and
 // writes it to the CSV file specified by the given path.
-func ExportSchedule(schedule *model.Schedule, path string) {
+func ExportSchedule(schedule *model.Schedule, path string, extension string) string {
 	nice := formatAndFilterSchedule(schedule)
+	// Get epoch timestamp and append it to file name
+	timestamp := strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
+	path = path + "_" + timestamp + extension
 	// Remove file if exists
 	_, err := os.Stat(path)
 	if err == nil {
@@ -32,6 +37,8 @@ func ExportSchedule(schedule *model.Schedule, path string) {
 	if err != nil {
 		panic(err)
 	}
+
+	return path
 }
 
 // PrintSchedule prints weekly schedule grouped by department name.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -32,7 +32,7 @@ func FillCourses(courses []*model.Course, schedule *model.Schedule, rooms []*mod
 					placed = tryPlaceIntoDay(course, schedule, day.DayOfWeek, day, rooms, schedule.TimeSlotCount/2+1)
 				}
 				if !placed {
-					placed = tryPlaceIntoDay(course, schedule, day.DayOfWeek, day, rooms, 1)
+					placed = tryPlaceIntoDay(course, schedule, day.DayOfWeek, day, rooms, 0)
 				}
 				if placed {
 					placedCount++

--- a/pkg/model/course.go
+++ b/pkg/model/course.go
@@ -25,4 +25,5 @@ type Course struct {
 	ReservedStartingTimeSlot int        `csv:"-"`
 	ReservedDay              int        `csv:"-"`
 	BusyDays                 []int      `csv:"-"`
+	Compulsory               bool       `csv:"-"`
 }

--- a/pkg/model/mandatory.go
+++ b/pkg/model/mandatory.go
@@ -1,0 +1,5 @@
+package model
+
+type Mandatory struct {
+	Course_Code string `csv:"Course_Code"`
+}


### PR DESCRIPTION
-Read in C/E data from input CSV file.
-Assign given data to courses if they exist.
-Disallow Conflict of Neighbouring Compulsory Courses (e.g., 1&2, 2&3, 3&4 and vice versa 2&1, 3&2, 4&3).
-Append epoch time to end of output file to keep track of all attempts.
-Increase iteration count to 10000.
-Revert starting time index to 8:30 for the time being.

![image](https://github.com/rhyrak/go-schedule/assets/82059810/032eca4a-a125-4dde-a505-2b6c6fc66408)

