### PR TITLE
Add daily AKTS limit for each grade

### DIFF
--- a/cmd/server/schedule.go
+++ b/cmd/server/schedule.go
@@ -60,16 +60,18 @@ func createAndExportSchedule(cfg *scheduler.Configuration) {
 
 		// Fill the empty schedule with course data and assign classrooms to courses
 		scheduler.PlaceReservedCourses(reserved, schedule, classrooms)
-		scheduler.FillCourses(courses, labs, schedule, classrooms, placementProbability, cfg.ActivityDay, congestedDepartments, cfg.DepartmentCongestionLimit)
+		allAssigned, _ := scheduler.FillCourses(courses, labs, schedule, classrooms, placementProbability, cfg.ActivityDay, congestedDepartments, cfg.DepartmentCongestionLimit)
 
-		// If schedule is valid, break, if not, shove everything out the window and try again (5dk)
-		valid, sufficientRooms, _, _ := scheduler.Validate(courses, labs, schedule, classrooms, congestedDepartments, cfg.DepartmentCongestionLimit)
-		if valid {
-			break
-		}
-		if !sufficientRooms {
-			// Ask user to enter new classroom(s)
-			// Continue with next iteration
+		if allAssigned {
+			// If schedule is valid, break, if not, shove everything out the window and try again (5dk)
+			valid, sufficientRooms, _, _ := scheduler.Validate(courses, labs, schedule, classrooms, congestedDepartments, cfg.DepartmentCongestionLimit)
+			if valid {
+				break
+			}
+			if !sufficientRooms {
+				// Ask user to enter new classroom(s)
+				// Continue with next iteration
+			}
 		}
 	}
 

--- a/internal/scheduler/validator.go
+++ b/internal/scheduler/validator.go
@@ -40,7 +40,7 @@ func Validate(courses []*model.Course, labs []*model.Laboratory, schedule *model
 			message += fmt.Sprintf("THEORY    %t %s %s %d %s\n", un.Compulsory, un.Course_Code, un.Department, un.Number_of_Students, un.Lecturer)
 		}
 		for _, un := range unassignedLabs {
-			message += fmt.Sprintf("THEORY    %t %s %s %d %s\n", un.Compulsory, un.Course_Code, un.Department, un.Number_of_Students, un.Lecturer)
+			message += fmt.Sprintf("LABORATORY    %t %s %s %d %s\n", un.Compulsory, un.Course_Code, un.Department, un.Number_of_Students, un.Lecturer)
 		}
 	}
 
@@ -89,8 +89,6 @@ func Validate(courses []*model.Course, labs []*model.Laboratory, schedule *model
 			}
 		}
 	*/
-	// !Silence warning
-	valid = !(!valid)
 	return valid, sufficientRooms, message, unassignedCount
 }
 

--- a/pkg/model/schedule.go
+++ b/pkg/model/schedule.go
@@ -8,9 +8,10 @@ type TimeSlot struct {
 }
 
 type Day struct {
-	Slots        []*TimeSlot
-	GradeCounter map[string][]int // GradeCounter["Department"][Grade] = PlacedCount
-	DayOfWeek    int
+	Slots              []*TimeSlot
+	GradeCounter       map[string][]int // GradeCounter["Department"][Grade] = PlacedCount
+	GradeCreditCounter map[string][]int // GradeCreditCounter["Department"][Grade] = PlacedAKTS
+	DayOfWeek          int
 }
 
 type Schedule struct {
@@ -43,6 +44,7 @@ func NewSchedule(days int, timeSlotDuration int, timeSlotCount int) *Schedule {
 			schedule.Days[i].Slots[j] = new(TimeSlot)
 		}
 		schedule.Days[i].GradeCounter = make(map[string][]int)
+		schedule.Days[i].GradeCreditCounter = make(map[string][]int)
 	}
 	rand.Shuffle(len(schedule.Days), func(i, j int) {
 		schedule.Days[i], schedule.Days[j] = schedule.Days[j], schedule.Days[i]


### PR DESCRIPTION
Limit to 10 total AKTS per department per grade per day. 
This should even out the distribution of Compulsory and Elective courses as those have different AKTS values.

Also perform an early exit when a course is not placed, stopping the program from wasting time filling up an invalid schedule.

Prettify printed info to screen in the CLI executable